### PR TITLE
Create Github workflow for Docker images on push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,17 @@
+name: Publish Docker image
+on:
+  push
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: diptochakrabarty/api
+          tag_with_ref: true


### PR DESCRIPTION
fixes DiptoChakrabarty/FlaskKube-api#2

To add a Github Workflow Action.
- on push, docker will build an image and push to docker hub
- use github secret values and docker repo value 'diptochakrabarty/api'

